### PR TITLE
Enable bus stop ref quest in Singapore

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/bus_stop_ref/AddBusStopRef.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/bus_stop_ref/AddBusStopRef.kt
@@ -31,6 +31,7 @@ class AddBusStopRef : OsmFilterQuestType<BusStopRefAnswer>(), AndroidQuest {
         "KR", // https://github.com/streetcomplete/StreetComplete/issues/6076
         "NZ", // https://wiki.openstreetmap.org/w/index.php?title=Talk:StreetComplete/Quests&oldid=2599288#Quests_in_New_Zealand
         "PT", // https://github.com/streetcomplete/StreetComplete/issues/5695
+        "SG",
         "TR", // https://github.com/streetcomplete/StreetComplete/issues/4489
         "US",
     )


### PR DESCRIPTION
Bus stops in Singapore have 5 digit ref codes, which are signed on the bus stop signs and on the bus route list at the bus stop.

Example: https://maps.app.goo.gl/Dau4mGb2Cz2xx5v68?g_st=ac

`ref` is already tagged on most bus stops: https://overpass-turbo.eu/s/2hzZ (5517 `highway=bus_stop`, 271 without `ref`)